### PR TITLE
fixed bs4 warning about default parser

### DIFF
--- a/default.py
+++ b/default.py
@@ -68,7 +68,7 @@ def post_auth(creds):
 
     if auth_resp.code == 200:
         #TODO: need to handle login locked scenario as well
-        soup = BeautifulSoup(rdata)
+        soup = BeautifulSoup(rdata,"html.parser")
         code = soup.find('code').get_text()
         if code == 'loginsuccess':
             return True


### PR DESCRIPTION
Kodi told me to do this:

15:56:46.274 T:140412910339840   ERROR: /home/kodi/.kodi/addons/script.module.beautifulsoup4/lib/bs4/__init__.py:181: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.
                                            
                                            The code that caused this warning is on line 390 of the file /home/kodi/.kodi/addons/plugin.video.ufcfightpass/default.py. To get rid of this warning, change code that looks like this:
                                            
                                             BeautifulSoup([your markup])
                                            
                                            to this:
                                            
                                             BeautifulSoup([your markup], "html.parser")
                                            
                                              markup_type=markup_type))
